### PR TITLE
Fix docker file (do not run make multi threaded) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /release /dev
 
 RUN cd release && git clone --single-branch --branch master https://github.com/LNIS-Projects/OpenFPGA.git OpenFPGA
 
-RUN cd /release/OpenFPGA && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=debug -DCMAKE_NO_GRAPHICS=on && make -j
+RUN cd /release/OpenFPGA && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=debug -DCMAKE_NO_GRAPHICS=on && make
 
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
As documented in `OpenFPGA/tutorials/building.md` one should not run `make -j` in Docker as `errors will happen`.