### PR TITLE
Update sc_dff_compact input names (to fix the tutorial)

### DIFF
--- a/vpr7_x2p/vpr/VerilogNetlists/ff.v
+++ b/vpr7_x2p/vpr/VerilogNetlists/ff.v
@@ -76,9 +76,9 @@ endmodule //End Of Module static_dff
 //-----------------------------------------------------
 module sc_dff_compact (
 /* Global ports go first */
-input reset, // Reset input 
+input pReset, // Reset input 
 //input set,     // set input
-input clk, // Clock Input
+input prog_clk, // Clock Input
 /* Local ports follow */
 input D, // Data Input
 output Q, // Q output 
@@ -88,8 +88,8 @@ output Qb // Q output
 reg q_reg;
 
 //-------------Code Starts Here---------
-always @ ( posedge clk or posedge reset /*or posedge set*/)
-if (reset) begin
+always @ ( posedge prog_clk or posedge pReset /*or posedge set*/)
+if (pReset) begin
   q_reg <= 1'b0;
 //end else if (set) begin
 //  q_reg <= 1'b1;


### PR DESCRIPTION
In order to get the tutorial running, I had to change the input names from `clk` and `reset` to `prog_clk` and `pReset` respectively. I'm not familiar with the project enough to judge if it breaks something in a different place. Please let me know if this change is fine or I should rather make the tutorial code use `clk` and `reset` instead. 