### PR TITLE
Fix GUI support with cmake 3.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.tar.gz"
+      CMAKE_URL="https://cmake.org/files/v3.16/cmake-3.16.3-Linux-x86_64.tar.gz"
       mkdir -p cmake && travis_retry wget --no-clobber --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
       echo ${PATH}

--- a/vpr7_x2p/vpr/CMakeLists.txt
+++ b/vpr7_x2p/vpr/CMakeLists.txt
@@ -17,7 +17,7 @@ message(STATUS "Checking VPR graphics option ${ENABLE_VPR_GRAPHICS}")
 if (ENABLE_VPR_GRAPHICS)
   # check for dependencies
   message(STATUS "VPR graphics is turned on, searching for dependencies")
-  find_package(X11 COMPONENTS X11 Xft)
+  find_package(X11)
 
   if (NOT X11_FOUND)
     message(WARNING "Failed to find required X11 library (on debian/ubuntu try 'sudo apt-get install libx11-dev' to install)")


### PR DESCRIPTION
Updated cmakelist to fix gui support with cmake > 3.12.  Tested on ubuntu 18.04, gcc8, cmake 3.16.3.
This is a hacky way to do it, but it works.