### PR TITLE
[Architecture Languange] Patch the default circuit model definition

### DIFF
--- a/docs/source/manual/arch_lang/circuit_library.rst
+++ b/docs/source/manual/arch_lang/circuit_library.rst
@@ -78,9 +78,9 @@ Here, we focus these common syntax and we will detail special syntax in :ref:`ci
 
 .. warning:: ``prefix`` may be deprecated soon
 
-.. note:: Multiplexers cannot be user-defined.
+.. warning:: Multiplexers cannot be user-defined.
 
-.. note:: For a circuit model type, only one circuit model can be set as default.
+.. warning:: For a circuit model type, only one circuit model is allowed to be set as default. If there is only one circuit model defined in a type, it will be considered as the default automatically.
 
 .. note:: If ``<spice_netlist>`` or ``<verilog_netlist>`` are not specified, FPGA-Verilog/SPICE auto-generates the Verilog/SPICE netlists for multiplexers, wires, and LUTs.
 

--- a/libopenfpga/libarchopenfpga/src/circuit_library.cpp
+++ b/libopenfpga/libarchopenfpga/src/circuit_library.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 
 #include "vtr_assert.h"
+#include "vtr_log.h"
 
 #include "openfpga_port_parser.h"
 #include "circuit_library.h"
@@ -2106,6 +2107,23 @@ void CircuitLibrary::build_timing_graphs() {
     set_timing_graph_delays(model_id);
   }
   return;
+}
+
+/* Automatically identify the default models for each type*/
+void CircuitLibrary::auto_detect_default_models() {
+  /* Go through the model fast look-up */
+  for (const auto& curr_type_models : model_lookup_) {
+    if ( (1 == curr_type_models.size())
+      && (false == model_is_default(curr_type_models[0]))) {
+      /* This is the only model in this type,
+       * it is safe to set it to be default
+       * Give a warning for users
+       */
+      set_model_is_default(curr_type_models[0], true);
+      VTR_LOG_WARN("Automatically set circuit model '%s' to be default in its type.\n",
+                   model_name(curr_type_models[0]).c_str());
+    }
+  }
 }
 
 /************************************************************************

--- a/libopenfpga/libarchopenfpga/src/circuit_library.h
+++ b/libopenfpga/libarchopenfpga/src/circuit_library.h
@@ -461,6 +461,10 @@ class CircuitLibrary {
   public: /* Public Mutators: builders */
     void build_model_links();
     void build_timing_graphs();
+    /* Automatically identify the default models for each type,
+     * suggest to do this after circuit library is built
+     */
+    void auto_detect_default_models();
   public: /* Internal mutators: build timing graphs */
     void add_edge(const CircuitModelId& model_id,
                   const CircuitPortId& from_port, const size_t& from_pin, 

--- a/libopenfpga/libarchopenfpga/src/read_xml_openfpga_arch.cpp
+++ b/libopenfpga/libarchopenfpga/src/read_xml_openfpga_arch.cpp
@@ -52,6 +52,9 @@ openfpga::Arch read_xml_openfpga_arch(const char* arch_file_name) {
     auto xml_circuit_models = get_single_child(xml_openfpga_arch, "circuit_library", loc_data);
     openfpga_arch.circuit_lib = read_xml_circuit_library(xml_circuit_models, loc_data);
 
+    /* Automatically identify the default models for circuit library */
+    openfpga_arch.circuit_lib.auto_detect_default_models();
+
     /* Build the internal links for the circuit library */
     openfpga_arch.circuit_lib.build_model_links();
   

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_40nm_openfpga.xml
@@ -184,7 +184,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_frac_mem32K_frac_dsp36_40nm_openfpga.xml
@@ -184,7 +184,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_40nm_openfpga.xml
@@ -184,7 +184,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_aib_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_chain_mem16K_aib_40nm_openfpga.xml
@@ -175,7 +175,7 @@
        <port type="output" prefix="Qb" size="1"/>
        <port type="clock" prefix="prog_clk" lib_name="clk" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
-    <circuit_model type="iopad" name="iopad" prefix="iopad" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/io.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/io.v">
+    <circuit_model type="iopad" name="iopad" prefix="iopad" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/io.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/io.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
@@ -184,7 +184,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_column_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_column_chain_40nm_openfpga.xml
@@ -184,7 +184,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_chain_40nm_openfpga.xml
@@ -184,7 +184,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_40nm_openfpga.xml
@@ -189,7 +189,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_40nm_openfpga.xml
@@ -189,7 +189,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_spypad_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_spypad_40nm_openfpga.xml
@@ -154,7 +154,7 @@
        <port type="output" prefix="Q" size="1"/>
        <port type="clock" prefix="clk" size="1" is_global="true" default_val="0" />
     </circuit_model>
-    <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" dump_structural_verilog="true">
+    <circuit_model type="lut" name="frac_lut6" prefix="frac_lut6" is_default="true" dump_structural_verilog="true">
       <design_technology type="cmos" fracturable_lut="true"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_spypad_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N10_adder_register_scan_chain_depop50_spypad_40nm_openfpga.xml
@@ -204,7 +204,7 @@
       <port type="input" prefix="outpad" size="1"/>
       <port type="output" prefix="inpad" size="1"/>
     </circuit_model>
-    <circuit_model type="hard_logic" name="adder" prefix="adder" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
+    <circuit_model type="hard_logic" name="adder" prefix="adder" is_default="true" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/SpiceNetlists/adder.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/VerilogNetlists/adder.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>


### PR DESCRIPTION
- Add check codes to help users debugging when default circuit models are not defined properly
- Add auto detection codes to identify unique and default circuit models
- Update documentation accordingly

Patch for issue #78 