### PR TITLE
Edits to enable basic run_fpga_flow.py

### DIFF
--- a/openfpga_flow/misc/fpgaflow_default_tool_path.conf
+++ b/openfpga_flow/misc/fpgaflow_default_tool_path.conf
@@ -7,11 +7,11 @@ odin2_path = ${PATH:OPENFPGA_PATH}/openfpga_flow/not_used_atm/odin2.exe
 abc_path = ${PATH:OPENFPGA_PATH}/yosys/yosys-abc
 abc_mccl_path = ${PATH:OPENFPGA_PATH}/abc_with_bb_support/abc
 abc_with_bb_support_path = ${PATH:OPENFPGA_PATH}/abc_with_bb_support/abc
-vpr_path = ${PATH:OPENFPGA_PATH}/vpr7_x2p/vpr/vpr
+vpr_path = ${PATH:OPENFPGA_PATH}/vpr/vpr
 ace_path = ${PATH:OPENFPGA_PATH}/ace2/ace
 pro_blif_path = ${PATH:OPENFPGA_PATH}/openfpga_flow/scripts/pro_blif.pl
 iverilog_path = iverilog
-include_netlist_verification = ${PATH:OPENFPGA_PATH}/vpr7_x2p/vpr/VerilogNetlists
+include_netlist_verification = ${PATH:OPENFPGA_PATH}/vpr/VerilogNetlists
 
 [FLOW_SCRIPT_CONFIG]
 valid_flows = standard,vpr_blif,vtr,vtr_standard,yosys_vpr

--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -672,7 +672,7 @@ def run_vpr():
                     min_channel_width)
         extract_vpr_stats(args.top_module+"_fr_chan_width_vpr.txt")
     else:
-        extract_vpr_stats(args.top_module+"_min_chan_width.txt")
+        extract_vpr_stats(args.top_module+"_min_chan_width_vpr.txt")
     if args.power:
         extract_vpr_stats(logfile=args.top_module+".power",
                           r_filename="vpr_power_stat",
@@ -716,11 +716,11 @@ def run_standard_vpr(bench_blif, fixed_chan_width, logfile, route_only=False):
                "--net_file", args.top_module+"_vpr.net",
                "--place_file", args.top_module+"_vpr.place",
                "--route_file", args.top_module+"_vpr.route",
-               "--full_stats",
+               "--full_stats", "on",
                "--activity_file", args.top_module+"_ace_out.act",
                ]
     if not args.disp:
-        command += ["--nodisp"]
+        command += ["--disp", "off"]
     if route_only:
         command += ["--route"]
     # Power options


### PR DESCRIPTION
Bug fixes to enable the following command

```
python3 ./openfpga_flow/scripts/run_fpga_flow.py ./openfpga_flow/vpr_arch/k4_frac_N4_40nm.xml ./openfpga_flow/benchmarks/micro_benchmark/and2/and2.v --top_module and2
```