### PR TITLE
Fixed blif formatting bug

### DIFF
--- a/openfpga_flow/scripts/run_fpga_flow.py
+++ b/openfpga_flow/scripts/run_fpga_flow.py
@@ -622,7 +622,7 @@ def run_vpr():
         args.top_module,
         args.top_module)
     cmd += r"| sed 's/$/./' | fold -s -w80 "
-    cmd += r"| sed 's/[^.]$/ \\/' | sed 's/[.]$/ /'"
+    cmd += r"| sed 's/[^.]$/ \\/' | sed 's/[.]$//'"
     cmd += " > %s.blif" % args.top_module
     os.system(cmd)
     if not args.fix_route_chan_width:


### PR DESCRIPTION
Needed to enable 
```
python3 ./openfpga_flow/scripts/run_fpga_flow.py ./openfpga_flow/vpr_arch/k6_frac_N10_40nm.xml 
    ./openfpga_flow/benchmarks/pipelined_8bit_adder/pipelined_8bit_adder.v  --top_module pipelined_8bit_adder
```