### PR TITLE
Multi-region support on Frame-based Configuration Protocol

### DIFF
--- a/.travis/basic_reg_test.sh
+++ b/.travis/basic_reg_test.sh
@@ -36,6 +36,8 @@ python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/config
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/configuration_frame_use_set --debug --show_thread_logs
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/configuration_frame_use_setb --debug --show_thread_logs
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/configuration_frame_use_set_reset --debug --show_thread_logs
+python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/multi_region_configuration_frame --debug --show_thread_logs
+python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/smart_fast_multi_region_configuration_frame --debug --show_thread_logs
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/preconfig_testbench/configuration_frame --debug --show_thread_logs
 
 echo -e "Testing memory bank configuration protocol of a K4N4 FPGA";
@@ -97,4 +99,3 @@ echo -e "Testing K4N5 with pattern based local routing";
 python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/k4_series/k4n5_pattern_local_routing --debug --show_thread_logs
 
 end_section "OpenFPGA.TaskTun"
-python3 openfpga_flow/scripts/run_fpga_task.py basic_tests/full_testbench/multi_region_memory_bank --debug --show_thread_logs

--- a/docs/source/manual/arch_lang/config_protocol.rst
+++ b/docs/source/manual/arch_lang/config_protocol.rst
@@ -41,6 +41,13 @@ Template
   - ``memory_bank`` requires a circuit model type of ``sram``
   - ``standalone`` requires a circuit model type of ``sram``
 
+.. option:: num_regions="<int>"
+
+  Specify the number of configuration regions to be used across the fabrics. By default, it will be only 1 configuration region. Each configuration region contains independent configuration protocols, but the whole fabric should employ the same type of configuration protocols. For example, an FPGA fabric consists of 4 configuration regions, each of which includes a configuration chain. The more configuration chain to be used, the fast configuration runtime will be, but at the cost of more I/Os in the FPGA fabrics. The organization of each configurable region can be customized through the fabric key (see details in :ref:`fabric_key`).
+
+  .. warning:: Currently, multiple configuration regions is not applicable to ``standalone`` configuration protocol.
+
+
 Configuration Chain Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following XML code describes a scan-chain circuitry to configure the core logic of FPGA, as illustrated in :numref:`fig_ccff_fpga`.
@@ -60,9 +67,6 @@ It will use the circuit model defined in :numref:`fig_ccff`.
  
    Example of a configuration chain to program core logic of a FPGA 
 
-.. option:: num_regions="<int>"
-
-  Specify the number of configuration chains to be used across the fabrics. By default, it will be only 1 configuration chain. The more configuration chain to be used, the fast configuration runtime will be, but at the cost of more I/Os in the FPGA fabrics. The organization of each configurable region can be customized through the fabric key (see details in :ref:`fabric_key`).
 
 .. figure:: figures/multi_region_config_chains.png
    :scale: 100%
@@ -112,6 +116,8 @@ When the decoder of sub block, e.g., the LUT, is enabled, each memory cells can 
   -  a Word-Line input to enable data write 
 
 .. warning:: Please do NOT add inverted Bit-Line and Word-Line inputs. It is not supported yet!
+
+When multiple configuration region is applied, the configuration frames will be grouped into different configuration regions. Each region has a separated data input bus and dedicated address decoders. As such, the configuration frame groups can be programmed in parallel.
 
 Memory bank Example
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/manual/fpga_bitstream/fabric_dependent_bitstream.rst
+++ b/docs/source/manual/fpga_bitstream/fabric_dependent_bitstream.rst
@@ -47,6 +47,8 @@ The information depends on the type of configuration procotol.
 .. option:: frame_based 
 
   Multiple lines will be included, each of which is organized as <address><space><bit>.
+  Note that the address may include don't care bit which is denoted as ``x``.
+  OpenFPGA automatically convert don't care bit to logic ``0`` when generating testbenches.
   For example
    
   .. code-block:: xml 
@@ -97,10 +99,12 @@ Other information may depend on the type of configuration procotol.
 
   - ``frame``: frame address information 
 
+  .. note:: Frame address may include don't care bit which is denoted as ``x``.
+
   A quick example:
 
   .. code-block:: xml
 
     <bit id="0" value="1" path="fpga_top.grid_clb_1__2_.logical_tile_clb_mode_clb__0.mem_fle_9_in_5.mem_out[0]"/>
-      <frame address="0000000000000000"/>
+      <frame address="0001000x00000x01"/>
     </bit>

--- a/libopenfpga/libopenfpgautil/src/openfpga_decode.cpp
+++ b/libopenfpga/libopenfpgautil/src/openfpga_decode.cpp
@@ -128,4 +128,54 @@ size_t bintoi_charvec(const std::vector<char>& bin) {
   return ret;
 }
 
+/******************************************************************** 
+ * Expand all the don't care bits in a string 
+ * A don't care 'x' can be decoded to either '0' or '1'
+ * For example:
+ *    input:  0x1x
+ *    output: 0010
+ *            0100
+ *            0101
+ *            0011
+ *
+ * Return all the strings
+ ********************************************************************/
+std::vector<std::string> expand_dont_care_bin_str(const std::string& input_str) {
+  std::vector<std::string> ret;
+
+  /* If the input is don't care free, we can retrun */
+  bool has_dont_care = false;
+  for (const char& bit : input_str) {
+    if (DONT_CARE_CHAR == bit) {
+      has_dont_care = true;
+      break;
+    }
+  }
+
+  if (false == has_dont_care) {
+    ret.push_back(input_str);
+    return ret;
+  }
+
+  /* Recusively expand all the don't bits */
+  for (size_t i = 0; i < input_str.length(); ++i) {
+    if (DONT_CARE_CHAR == input_str[i]) {
+      std::string temp_input_str = input_str;
+      /* Flip to '0' and go recursively */
+      temp_input_str[i] = '0';  
+      for (const std::string& expanded_str : expand_dont_care_bin_str(temp_input_str)) {
+        ret.push_back(expanded_str);
+      }
+      /* Flip to '1' and go recursively */
+      temp_input_str[i] = '1';  
+      for (const std::string& expanded_str : expand_dont_care_bin_str(temp_input_str)) {
+        ret.push_back(expanded_str);
+      }
+      break;
+    }
+  }
+
+  return ret;
+}
+
 } /* end namespace openfpga */

--- a/libopenfpga/libopenfpgautil/src/openfpga_decode.h
+++ b/libopenfpga/libopenfpgautil/src/openfpga_decode.h
@@ -6,12 +6,18 @@
  *******************************************************************/
 #include <stddef.h>
 #include <vector>
+#include <string>
 
 /********************************************************************
  * Function declaration
  *******************************************************************/
 /* namespace openfpga begins */
 namespace openfpga {
+
+/**************************************** 
+ * Constants 
+ */
+constexpr char DONT_CARE_CHAR = 'x';
 
 std::vector<size_t> ito1hot_vec(const size_t& in_int,
                                 const size_t& bin_len);
@@ -23,6 +29,8 @@ std::vector<char> itobin_charvec(const size_t& in_int,
                                  const size_t& bin_len);
 
 size_t bintoi_charvec(const std::vector<char>& bin);
+
+std::vector<std::string> expand_dont_care_bin_str(const std::string& input_str);
 
 } /* namespace openfpga ends */
 

--- a/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
@@ -85,14 +85,13 @@ size_t rec_estimate_device_bitstream_num_bits(const ModuleManager& module_manage
     for (const ConfigRegionId& config_region : module_manager.regions(parent_module)) {
       size_t curr_region_num_config_child = module_manager.region_configurable_children(parent_module, config_region).size();
 
-      /* FIXME: This will be uncommented when multi-region support is extended for frame-based 
-       * Frame-based configuration protocol will have 1 decoder
+      /* Frame-based configuration protocol will have 1 decoder
        * if there are more than 1 configurable children
+       */
       if ( (CONFIG_MEM_FRAME_BASED == config_protocol_type)
         && (2 <= curr_region_num_config_child)) {
         curr_region_num_config_child--;
       }
-       */
 
       /* Memory configuration protocol will have 2 decoders
        * at the top-level

--- a/openfpga/src/fpga_bitstream/build_fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_fabric_bitstream.cpp
@@ -281,6 +281,8 @@ static
 void rec_build_module_fabric_dependent_frame_bitstream(const BitstreamManager& bitstream_manager,
                                                        const std::vector<ConfigBlockId>& parent_blocks,
                                                        const ModuleManager& module_manager,
+                                                       const ModuleId& top_module,
+                                                       const ConfigRegionId& config_region,
                                                        const std::vector<ModuleId>& parent_modules,
                                                        const std::vector<char>& addr_code,
                                                        FabricBitstream& fabric_bitstream,
@@ -293,7 +295,18 @@ void rec_build_module_fabric_dependent_frame_bitstream(const BitstreamManager& b
     const ConfigBlockId& parent_block = parent_blocks.back();
     const ModuleId& parent_module = parent_modules.back();
 
-    size_t num_configurable_children = module_manager.configurable_children(parent_modules.back()).size();
+    std::vector<ModuleId> configurable_children;
+    std::vector<size_t> configurable_child_instances;
+    if (top_module == parent_module) {
+      configurable_children = module_manager.region_configurable_children(parent_module, config_region);
+      configurable_child_instances = module_manager.region_configurable_child_instances(parent_module, config_region);
+    } else {
+      VTR_ASSERT(top_module != parent_module);
+      configurable_children = module_manager.configurable_children(parent_module);
+      configurable_child_instances = module_manager.configurable_child_instances(parent_module);
+    }
+
+    size_t num_configurable_children = configurable_children.size();
  
     size_t max_child_addr_code_size = 0;
     bool add_addr_code = true;
@@ -318,11 +331,11 @@ void rec_build_module_fabric_dependent_frame_bitstream(const BitstreamManager& b
      */
       VTR_ASSERT(2 < num_configurable_children);
       num_configurable_children--;
-      decoder_module = module_manager.configurable_children(parent_module).back();
+      decoder_module = configurable_children.back();
 
       /* The address code size is the max. of address port of all the configurable children */
       for (size_t child_id = 0; child_id < num_configurable_children; ++child_id) {
-        ModuleId child_module = module_manager.configurable_children(parent_module)[child_id]; 
+        ModuleId child_module = configurable_children[child_id]; 
         const ModulePortId& child_addr_port_id = module_manager.find_module_port(child_module, std::string(DECODER_ADDRESS_PORT_NAME));
         const BasicPort& child_addr_port = module_manager.module_port(child_module, child_addr_port_id);
         max_child_addr_code_size = std::max((int)child_addr_port.get_width(), (int)max_child_addr_code_size);
@@ -330,15 +343,14 @@ void rec_build_module_fabric_dependent_frame_bitstream(const BitstreamManager& b
     }
 
     for (size_t child_id = 0; child_id < num_configurable_children; ++child_id) {
-      ModuleId child_module = module_manager.configurable_children(parent_module)[child_id]; 
-      size_t child_instance = module_manager.configurable_child_instances(parent_module)[child_id]; 
+      ModuleId child_module = configurable_children[child_id]; 
+      size_t child_instance = configurable_child_instances[child_id]; 
       /* Get the instance name and ensure it is not empty */
       std::string instance_name = module_manager.instance_name(parent_module, child_module, child_instance);
        
       /* Find the child block that matches the instance name! */ 
       ConfigBlockId child_block = bitstream_manager.find_child_block(parent_block, instance_name); 
       /* We must have one valid block id! */
-      if (true != bitstream_manager.valid_block_id(child_block))
       VTR_ASSERT(true == bitstream_manager.valid_block_id(child_block));
 
       /* Pass on the list of blocks, modules and address lists */
@@ -400,7 +412,10 @@ void rec_build_module_fabric_dependent_frame_bitstream(const BitstreamManager& b
 
       /* Go recursively */
       rec_build_module_fabric_dependent_frame_bitstream(bitstream_manager, child_blocks,
-                                                        module_manager, child_modules,
+                                                        module_manager,
+                                                        top_module,
+                                                        config_region,
+                                                        child_modules,
                                                         child_addr_code,
                                                         fabric_bitstream,
                                                         fabric_bitstream_region);
@@ -417,9 +432,15 @@ void rec_build_module_fabric_dependent_frame_bitstream(const BitstreamManager& b
    * We will find the address bit and add it to addr_code
    * Then we can add the configuration bits to the fabric_bitstream.
    */
-  if (!(1 < module_manager.configurable_children(parent_modules.back()).size()))
-  VTR_ASSERT(1 < module_manager.configurable_children(parent_modules.back()).size());
-  ModuleId decoder_module = module_manager.configurable_children(parent_modules.back()).back();
+  std::vector<ModuleId> configurable_children;
+  if (top_module == parent_modules.back()) {
+    configurable_children = module_manager.region_configurable_children(parent_modules.back(), config_region);
+  } else {
+    VTR_ASSERT(top_module != parent_modules.back());
+    configurable_children = module_manager.configurable_children(parent_modules.back());
+  }
+
+  ModuleId decoder_module = configurable_children.back();
   /* Find the address port from the decoder module */
   const ModulePortId& decoder_addr_port_id = module_manager.find_module_port(decoder_module, std::string(DECODER_ADDRESS_PORT_NAME));
   const BasicPort& decoder_addr_port = module_manager.module_port(decoder_module, decoder_addr_port_id);
@@ -557,6 +578,8 @@ void build_module_fabric_dependent_bitstream(const ConfigProtocol& config_protoc
       rec_build_module_fabric_dependent_frame_bitstream(bitstream_manager,
                                                         std::vector<ConfigBlockId>(1, top_block),
                                                         module_manager,
+                                                        top_module,
+                                                        config_region,
                                                         std::vector<ModuleId>(1, top_module),
 	  												    std::vector<char>(),
                                                         fabric_bitstream,

--- a/openfpga/src/fpga_bitstream/fabric_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/fabric_bitstream.cpp
@@ -68,7 +68,7 @@ std::vector<char> FabricBitstream::bit_address(const FabricBitId& bit_id) const 
   VTR_ASSERT(true == valid_bit_id(bit_id));
   VTR_ASSERT(true == use_address_);
 
-  return itobin_charvec(bit_addresses_[bit_id], address_length_);
+  return bit_addresses_[bit_id];
 }
 
 std::vector<char> FabricBitstream::bit_bl_address(const FabricBitId& bit_id) const {
@@ -81,7 +81,7 @@ std::vector<char> FabricBitstream::bit_wl_address(const FabricBitId& bit_id) con
   VTR_ASSERT(true == use_address_);
   VTR_ASSERT(true == use_wl_address_);
 
-  return itobin_charvec(bit_wl_addresses_[bit_id], wl_address_length_);
+  return bit_wl_addresses_[bit_id];
 }
 
 char FabricBitstream::bit_din(const FabricBitId& bit_id) const {
@@ -122,6 +122,16 @@ FabricBitId FabricBitstream::add_bit(const ConfigBitId& config_bit_id) {
   num_bits_++;
   config_bit_ids_.push_back(config_bit_id);
 
+  if (true == use_address_) {
+    bit_addresses_.emplace_back();
+    bit_dins_.emplace_back();
+ 
+    if (true == use_wl_address_) {
+      bit_wl_addresses_.emplace_back();
+    }
+  }
+
+
   return bit; 
 }
 
@@ -130,7 +140,7 @@ void FabricBitstream::set_bit_address(const FabricBitId& bit_id,
   VTR_ASSERT(true == valid_bit_id(bit_id));
   VTR_ASSERT(true == use_address_);
   VTR_ASSERT(address_length_ == address.size());
-  bit_addresses_[bit_id] = bintoi_charvec(address);
+  bit_addresses_[bit_id] = address;
 }
 
 void FabricBitstream::set_bit_bl_address(const FabricBitId& bit_id,
@@ -144,7 +154,7 @@ void FabricBitstream::set_bit_wl_address(const FabricBitId& bit_id,
   VTR_ASSERT(true == use_address_);
   VTR_ASSERT(true == use_wl_address_);
   VTR_ASSERT(wl_address_length_ == address.size());
-  bit_wl_addresses_[bit_id] = bintoi_charvec(address);
+  bit_wl_addresses_[bit_id] = address;
 }
 
 void FabricBitstream::set_bit_din(const FabricBitId& bit_id,

--- a/openfpga/src/fpga_bitstream/fabric_bitstream.h
+++ b/openfpga/src/fpga_bitstream/fabric_bitstream.h
@@ -208,8 +208,8 @@ class FabricBitstream {
      *
      * We use a 2-element array, as we may have a BL address and a WL address
      */
-    vtr::vector<FabricBitId, size_t> bit_addresses_;
-    vtr::vector<FabricBitId, size_t> bit_wl_addresses_;
+    vtr::vector<FabricBitId, std::vector<char>> bit_addresses_;
+    vtr::vector<FabricBitId, std::vector<char>> bit_wl_addresses_;
 
     /* Data input (Din) bits: this is designed for memory decoders */
     vtr::vector<FabricBitId, char> bit_dins_;

--- a/openfpga/src/fpga_bitstream/fabric_bitstream.h
+++ b/openfpga/src/fpga_bitstream/fabric_bitstream.h
@@ -207,6 +207,10 @@ class FabricBitstream {
      * to the configuration protocol directly 
      *
      * We use a 2-element array, as we may have a BL address and a WL address
+     *
+     * TODO: use nested vector may cause large memory footprint 
+     *       when bitstream size increases
+     *       NEED TO THINK ABOUT A COMPACT MODELING
      */
     vtr::vector<FabricBitId, std::vector<char>> bit_addresses_;
     vtr::vector<FabricBitId, std::vector<char>> bit_wl_addresses_;

--- a/openfpga/src/fpga_verilog/verilog_decoders.cpp
+++ b/openfpga/src/fpga_verilog/verilog_decoders.cpp
@@ -295,14 +295,17 @@ void print_verilog_arch_decoder_module(std::fstream& fp,
   /* Print the truth table of this decoder */
   /* Internal logics */
   /* Early exit: Corner case for data size = 1 the logic is very simple:
-   * data = addr;  
-   * data_inv = ~data_inv
+   * when enable is '1' and and address is '0'
+   * data_out is driven by '1'
+   * else data_out is driven by '0'
    */
   if (1 == data_size) {
     fp << "always@(" << generate_verilog_port(VERILOG_PORT_CONKT, addr_port);
     fp << " or " << generate_verilog_port(VERILOG_PORT_CONKT, enable_port);
     fp << ") begin" << std::endl;
-    fp << "\tif (" << generate_verilog_port(VERILOG_PORT_CONKT, enable_port) << " == 1'b1) begin" << std::endl;
+    fp << "\tif ((" << generate_verilog_port(VERILOG_PORT_CONKT, enable_port) << " == 1'b1) && ("; 
+    fp << generate_verilog_port(VERILOG_PORT_CONKT, addr_port) << " == 1'b0))"; 
+    fp << " begin" << std::endl;
     fp << "\t\t" << generate_verilog_port_constant_values(data_port, std::vector<size_t>(1, 1)) << ";" << std::endl; 
     fp << "\t" << "end else begin" << std::endl;
     fp << "\t\t" << generate_verilog_port_constant_values(data_port, std::vector<size_t>(1, 0)) << ";" << std::endl; 

--- a/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
+++ b/openfpga/src/fpga_verilog/verilog_top_testbench.cpp
@@ -699,17 +699,24 @@ size_t calculate_num_config_clock_cycles(const e_config_protocol_type& sram_orgz
               100. * ((float)num_config_clock_cycles / (float)(1 + regional_bitstream_max_size) - 1.));
     }
     break;
-  case CONFIG_MEM_MEMORY_BANK:
-  case CONFIG_MEM_FRAME_BASED: {
+  case CONFIG_MEM_MEMORY_BANK: {
     /* For fast configuration, we will skip all the zero data points */
+    num_config_clock_cycles = 1 + build_memory_bank_fabric_bitstream_by_address(fabric_bitstream).size();
     if (true == fast_configuration) {
       size_t full_num_config_clock_cycles = num_config_clock_cycles;
-      num_config_clock_cycles = 1;
-      for (const FabricBitId& bit_id : fabric_bitstream.bits()) {
-        if (bit_value_to_skip != fabric_bitstream.bit_din(bit_id)) {
-          num_config_clock_cycles++;
-        }
-      }
+      num_config_clock_cycles = 1 + find_memory_bank_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
+      VTR_LOG("Fast configuration reduces number of configuration clock cycles from %lu to %lu (compression_rate = %f%)\n",
+              full_num_config_clock_cycles,
+              num_config_clock_cycles,
+              100. * ((float)num_config_clock_cycles / (float)full_num_config_clock_cycles - 1.));
+    }
+    break;
+  }
+  case CONFIG_MEM_FRAME_BASED: {
+    num_config_clock_cycles = 1 + build_frame_based_fabric_bitstream_by_address(fabric_bitstream).size();
+    if (true == fast_configuration) {
+      size_t full_num_config_clock_cycles = num_config_clock_cycles;
+      num_config_clock_cycles = 1 + find_frame_based_fast_configuration_fabric_bitstream_size(fabric_bitstream, bit_value_to_skip);
       VTR_LOG("Fast configuration reduces number of configuration clock cycles from %lu to %lu (compression_rate = %f%)\n",
               full_num_config_clock_cycles,
               num_config_clock_cycles,
@@ -1529,46 +1536,8 @@ void print_verilog_top_testbench_memory_bank_bitstream(std::fstream& fp,
 
   fp << std::endl;
 
-  /* Reorganize the fabric bitstream by the same address across regions:
-   * This is due to that the length of fabric bitstream could be different in each region.
-   * Template:
-   *   <bl_address> <wl_address> <din_values_from_different_regions>
-   * An example:
-   *   000000  00000 1011
-   *
-   * Note: the std::map may cause large memory footprint for large bitstream databases!
-   */
-  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr;
-  for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
-    for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
-      /* Create string for BL address */
-      VTR_ASSERT(bl_addr_port.get_width() == fabric_bitstream.bit_bl_address(bit_id).size());
-      std::string bl_addr_str;
-      for (const char& addr_bit : fabric_bitstream.bit_bl_address(bit_id)) {
-        bl_addr_str.push_back(addr_bit);
-      }
-
-      /* Create string for WL address */
-      VTR_ASSERT(wl_addr_port.get_width() == fabric_bitstream.bit_wl_address(bit_id).size());
-      std::string wl_addr_str;
-      for (const char& addr_bit : fabric_bitstream.bit_wl_address(bit_id)) {
-        wl_addr_str.push_back(addr_bit);
-      }
-
-      /* Place the config bit */
-      auto result = fabric_bits_by_addr.find(std::make_pair(bl_addr_str, wl_addr_str));
-      if (result == fabric_bits_by_addr.end()) {
-        /* This is a new bit, resize the vector to the number of regions
-         * and deposit '0' to all the bits
-         */
-        fabric_bits_by_addr[std::make_pair(bl_addr_str, wl_addr_str)] = std::vector<bool>(fabric_bitstream.regions().size(), false);
-        fabric_bits_by_addr[std::make_pair(bl_addr_str, wl_addr_str)][size_t(region)] = fabric_bitstream.bit_din(bit_id);
-      } else {
-        VTR_ASSERT_SAFE(result != fabric_bits_by_addr.end());
-        result->second[size_t(region)] = fabric_bitstream.bit_din(bit_id);
-      }
-    }
-  }
+  /* Reorganize the fabric bitstream by the same address across regions */
+  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
 
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
     /* When fast configuration is enabled,
@@ -1676,39 +1645,8 @@ void print_verilog_top_testbench_frame_decoder_bitstream(std::fstream& fp,
 
   fp << std::endl;
 
-  /* Reorganize the fabric bitstream by the same address across regions:
-   * This is due to that the length of fabric bitstream could be different in each region.
-   * Template:
-   *   <address> <din_values_from_different_regions>
-   * An example:
-   *   000000 1011
-   *
-   * Note: the std::map may cause large memory footprint for large bitstream databases!
-   */
-  std::map<std::string, std::vector<bool>> fabric_bits_by_addr;
-  for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
-    for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
-      /* Create string for address */
-      VTR_ASSERT(addr_port.get_width() == fabric_bitstream.bit_address(bit_id).size());
-      std::string addr_str;
-      for (const char& addr_bit : fabric_bitstream.bit_address(bit_id)) {
-        addr_str.push_back(addr_bit);
-      }
-
-      /* Place the config bit */
-      auto result = fabric_bits_by_addr.find(addr_str);
-      if (result == fabric_bits_by_addr.end()) {
-        /* This is a new bit, resize the vector to the number of regions
-         * and deposit '0' to all the bits
-         */
-        fabric_bits_by_addr[addr_str] = std::vector<bool>(fabric_bitstream.regions().size(), false);
-        fabric_bits_by_addr[addr_str][size_t(region)] = fabric_bitstream.bit_din(bit_id);
-      } else {
-        VTR_ASSERT_SAFE(result != fabric_bits_by_addr.end());
-        result->second[size_t(region)] = fabric_bitstream.bit_din(bit_id);
-      }
-    }
-  }
+  /* Reorganize the fabric bitstream by the same address across regions */
+  std::map<std::string, std::vector<bool>> fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
 
   for (const auto& addr_din_pair : fabric_bits_by_addr) {
     /* When fast configuration is enabled,
@@ -1735,7 +1673,7 @@ void print_verilog_top_testbench_frame_decoder_bitstream(std::fstream& fp,
     VTR_ASSERT(addr_port.get_width() == addr_din_pair.first.size());
     fp << addr_din_pair.first;
     fp << ", ";
-    fp <<"1'b";
+    fp << din_port.get_width() << "'b";
     VTR_ASSERT(din_port.get_width() == addr_din_pair.second.size());
     for (const bool& din_value : addr_din_pair.second) {
       if (true == din_value) {
@@ -1748,7 +1686,7 @@ void print_verilog_top_testbench_frame_decoder_bitstream(std::fstream& fp,
     fp << ");" << std::endl;
   }
 
-  /* Disable the address and din */
+  /* Disable the address and din 
   fp << "\t\t" << std::string(TOP_TESTBENCH_PROG_TASK_NAME);
   fp << "(" << addr_port.get_width() << "'b";
   std::vector<size_t> all_zero_addr(addr_port.get_width(), 0);
@@ -1756,8 +1694,9 @@ void print_verilog_top_testbench_frame_decoder_bitstream(std::fstream& fp,
     fp << addr_bit;
   }
   fp << ", ";
-  fp <<"1'b0";
+  fp << generate_verilog_constant_values(initial_din_values);
   fp << ");" << std::endl;
+  */
 
   /* Raise the flag of configuration done when bitstream loading is complete */
   BasicPort prog_clock_port(std::string(TOP_TB_PROG_CLOCK_PORT_NAME), 1);

--- a/openfpga/src/utils/fabric_bitstream_utils.cpp
+++ b/openfpga/src/utils/fabric_bitstream_utils.cpp
@@ -64,4 +64,172 @@ size_t find_configuration_chain_fabric_bitstream_size_to_be_skipped(const Fabric
   return num_bits_to_skip;
 }
 
+/********************************************************************
+ * Reorganize the fabric bitstream for frame-based protocol
+ * by the same address across regions:
+ * This is due to that the length of fabric bitstream could be different in each region.
+ * Template:
+ *   <address> <din_values_from_different_regions>
+ * An example:
+ *   000000 1011
+ *
+ * Note: the std::map may cause large memory footprint for large bitstream databases!
+ *******************************************************************/
+std::map<std::string, std::vector<bool>> build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream) {
+  std::map<std::string, std::vector<bool>> fabric_bits_by_addr;
+  for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
+    for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
+      /* Create string for address */
+      std::string addr_str;
+      for (const char& addr_bit : fabric_bitstream.bit_address(bit_id)) {
+        addr_str.push_back(addr_bit);
+      }
+
+      /* Place the config bit */
+      auto result = fabric_bits_by_addr.find(addr_str);
+      if (result == fabric_bits_by_addr.end()) {
+        /* This is a new bit, resize the vector to the number of regions
+         * and deposit '0' to all the bits
+         */
+        fabric_bits_by_addr[addr_str] = std::vector<bool>(fabric_bitstream.regions().size(), false);
+        fabric_bits_by_addr[addr_str][size_t(region)] = fabric_bitstream.bit_din(bit_id);
+      } else {
+        VTR_ASSERT_SAFE(result != fabric_bits_by_addr.end());
+        result->second[size_t(region)] = fabric_bitstream.bit_din(bit_id);
+      }
+    }
+  }
+  
+  return fabric_bits_by_addr;
+}
+
+/********************************************************************
+ * For fast configuration, the number of bits to be skipped
+ * the rule to skip any configuration bit should consider the whole data input values.
+ * Only all the bits in the din port match the value to be skipped,
+ * the programming cycle can be skipped!
+ * For example:
+ *   Address: 010101
+ *     Region 0: 0
+ *     Region 1: 1 
+ *     Region 2: 0 
+ *   This bit cannot be skipped if the bit_value_to_skip is 0
+ *
+ *   Address: 010101
+ *     Region 0: 0
+ *     Region 1: 0 
+ *     Region 2: 0 
+ *   This bit can be skipped if the bit_value_to_skip is 0
+ *******************************************************************/
+size_t find_frame_based_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
+                                                                 const bool& bit_value_to_skip) {
+  std::map<std::string, std::vector<bool>> fabric_bits_by_addr = build_frame_based_fabric_bitstream_by_address(fabric_bitstream);
+
+  size_t num_bits = 0;
+
+  for (const auto& addr_din_pair : fabric_bits_by_addr) {
+    bool skip_curr_bits = true;
+    for (const bool& bit : addr_din_pair.second) {
+      if (bit_value_to_skip != bit) {
+        skip_curr_bits = false;
+        break;
+      }
+    }
+
+    if (false == skip_curr_bits) {
+      num_bits++;
+    }
+  }
+
+  return num_bits;
+}
+
+/********************************************************************
+ * Reorganize the fabric bitstream for memory banks
+ * by the same address across regions:
+ * This is due to that the length of fabric bitstream could be different in each region.
+ * Template:
+ *   <bl_address> <wl_address> <din_values_from_different_regions>
+ * An example:
+ *   000000  00000 1011
+ *
+ * Note: the std::map may cause large memory footprint for large bitstream databases!
+ *******************************************************************/
+std::map<std::pair<std::string, std::string>, std::vector<bool>> build_memory_bank_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream) {
+  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr;
+  for (const FabricBitRegionId& region : fabric_bitstream.regions()) {
+    for (const FabricBitId& bit_id : fabric_bitstream.region_bits(region)) {
+      /* Create string for BL address */
+      std::string bl_addr_str;
+      for (const char& addr_bit : fabric_bitstream.bit_bl_address(bit_id)) {
+        bl_addr_str.push_back(addr_bit);
+      }
+
+      /* Create string for WL address */
+      std::string wl_addr_str;
+      for (const char& addr_bit : fabric_bitstream.bit_wl_address(bit_id)) {
+        wl_addr_str.push_back(addr_bit);
+      }
+
+      /* Place the config bit */
+      auto result = fabric_bits_by_addr.find(std::make_pair(bl_addr_str, wl_addr_str));
+      if (result == fabric_bits_by_addr.end()) {
+        /* This is a new bit, resize the vector to the number of regions
+         * and deposit '0' to all the bits
+         */
+        fabric_bits_by_addr[std::make_pair(bl_addr_str, wl_addr_str)] = std::vector<bool>(fabric_bitstream.regions().size(), false);
+        fabric_bits_by_addr[std::make_pair(bl_addr_str, wl_addr_str)][size_t(region)] = fabric_bitstream.bit_din(bit_id);
+      } else {
+        VTR_ASSERT_SAFE(result != fabric_bits_by_addr.end());
+        result->second[size_t(region)] = fabric_bitstream.bit_din(bit_id);
+      }
+    }
+  }
+
+  return fabric_bits_by_addr;
+}
+
+/********************************************************************
+ * For fast configuration, the number of bits to be skipped
+ * the rule to skip any configuration bit should consider the whole data input values.
+ * Only all the bits in the din port match the value to be skipped,
+ * the programming cycle can be skipped!
+ * For example:
+ *   BL Address: 010101
+ *   WL Address: 010101
+ *     Region 0: 0
+ *     Region 1: 1 
+ *     Region 2: 0 
+ *   This bit cannot be skipped if the bit_value_to_skip is 0
+ *
+ *   BL Address: 010101
+ *   WL Address: 010101
+ *     Region 0: 0
+ *     Region 1: 0 
+ *     Region 2: 0 
+ *   This bit can be skipped if the bit_value_to_skip is 0
+ *******************************************************************/
+size_t find_memory_bank_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
+                                                                 const bool& bit_value_to_skip) {
+  std::map<std::pair<std::string, std::string>, std::vector<bool>> fabric_bits_by_addr = build_memory_bank_fabric_bitstream_by_address(fabric_bitstream);
+
+  size_t num_bits = 0;
+
+  for (const auto& addr_din_pair : fabric_bits_by_addr) {
+    bool skip_curr_bits = true;
+    for (const bool& bit : addr_din_pair.second) {
+      if (bit_value_to_skip != bit) {
+        skip_curr_bits = false;
+        break;
+      }
+    }
+
+    if (false == skip_curr_bits) {
+      num_bits++;
+    }
+  }
+
+  return num_bits;
+}
+
 } /* end namespace openfpga */

--- a/openfpga/src/utils/fabric_bitstream_utils.h
+++ b/openfpga/src/utils/fabric_bitstream_utils.h
@@ -8,6 +8,7 @@
  * Include header files that are required by function declaration
  *******************************************************************/
 #include <vector>
+#include <map>
 #include "bitstream_manager.h"
 #include "fabric_bitstream.h"
 
@@ -23,6 +24,16 @@ size_t find_fabric_regional_bitstream_max_size(const FabricBitstream& fabric_bit
 size_t find_configuration_chain_fabric_bitstream_size_to_be_skipped(const FabricBitstream& fabric_bitstream,
                                                                     const BitstreamManager& bitstream_manager,
                                                                     const bool& bit_value_to_skip);
+
+std::map<std::string, std::vector<bool>> build_frame_based_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);
+
+size_t find_frame_based_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
+                                                                 const bool& bit_value_to_skip);
+
+std::map<std::pair<std::string, std::string>, std::vector<bool>> build_memory_bank_fabric_bitstream_by_address(const FabricBitstream& fabric_bitstream);
+
+size_t find_memory_bank_fast_configuration_fabric_bitstream_size(const FabricBitstream& fabric_bitstream,
+                                                                 const bool& bit_value_to_skip);
 
 } /* end namespace openfpga */
 

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_openfpga.xml
@@ -1,0 +1,198 @@
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="input" prefix="sel" size="1"/>
+      <port type="input" prefix="selb" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf" prefix="mux_2level_tapbuf" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level_tapbuf" prefix="mux_1level_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="one_level" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+       <design_technology type="cmos"/>
+       <input_buffer exist="true" circuit_model_name="INVTX1"/>
+       <output_buffer exist="true" circuit_model_name="INVTX1"/>
+       <port type="input" prefix="D" size="1"/>
+       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+       <port type="output" prefix="Q" size="1"/>
+       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+    </circuit_model>
+    <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="16"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="sram" name="LATCH" prefix="LATCH" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
+       <design_technology type="cmos"/>
+       <input_buffer exist="true" circuit_model_name="INVTX1"/>
+       <output_buffer exist="true" circuit_model_name="INVTX1"/>
+       <port type="bl" prefix="bl" lib_name="D" size="1"/>
+       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+       <port type="output" prefix="Q" lib_name="Q" size="1"/>
+       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="LATCH" default_val="1"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="frame_based" circuit_model_name="LATCH" num_regions="4"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_2level_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="0" circuit_model_name="mux_2level_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L4" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <!-- End physical pb_type binding in complex block IO -->
+
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_2level"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" circuit_model_name="lut4"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff" circuit_model_name="DFFSRQ"/>
+    <!-- End physical pb_type binding in complex block IO -->
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_use_both_set_reset_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_use_both_set_reset_openfpga.xml
@@ -1,0 +1,200 @@
+<!-- Architecture annotation for OpenFPGA framework
+     This annotation supports the k6_N10_40nm.xml 
+     - General purpose logic block
+       - K = 6, N = 10, I = 40
+       - Single mode
+     - Routing architecture
+       - L = 4, fc_in = 0.15, fc_out = 0.1
+  -->
+<openfpga_architecture>
+  <technology_library>
+    <device_library>
+      <device_model name="logic" type="transistor">
+        <lib type="industry" corner="TOP_TT" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="0.9" pn_ratio="2"/>
+        <pmos name="pch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+        <nmos name="nch" chan_length="40e-9" min_width="140e-9" variation="logic_transistor_var"/>
+      </device_model>
+      <device_model name="io" type="transistor">
+        <lib type="academia" ref="M" path="${OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.pm"/>
+        <design vdd="2.5" pn_ratio="3"/>
+        <pmos name="pch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+        <nmos name="nch_25" chan_length="270e-9" min_width="320e-9" variation="io_transistor_var"/>
+      </device_model>
+    </device_library>
+    <variation_library>
+      <variation name="logic_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+      <variation name="io_transistor_var" abs_deviation="0.1" num_sigma="3"/>
+    </variation_library>
+  </technology_library>
+  <circuit_library>
+    <circuit_model type="inv_buf" name="INVTX1" prefix="INVTX1" is_default="true">
+      <design_technology type="cmos" topology="inverter" size="1"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="buf4" prefix="buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="2" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="inv_buf" name="tap_buf4" prefix="tap_buf4" is_default="false">
+      <design_technology type="cmos" topology="buffer" size="1" num_level="3" f_per_stage="4"/>
+      <device_technology device_model_name="logic"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in" out_port="out">
+        10e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="pass_gate" name="TGATE" prefix="TGATE" is_default="true">
+      <design_technology type="cmos" topology="transmission_gate" nmos_size="1" pmos_size="2"/>
+      <device_technology device_model_name="logic"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="input" prefix="sel" size="1"/>
+      <port type="input" prefix="selb" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <delay_matrix type="rise" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+      <delay_matrix type="fall" in_port="in sel selb" out_port="out">
+        10e-12 5e-12 5e-12
+      </delay_matrix>
+    </circuit_model>
+    <circuit_model type="chan_wire" name="chan_segment" prefix="track_seg" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="101" C="22.5e-15" num_level="1"/> <!-- model_type could be T, res_val and cap_val DON'T CARE -->
+    </circuit_model>
+    <circuit_model type="wire" name="direct_interc" prefix="direct_interc" is_default="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="false"/>
+      <output_buffer exist="false"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <wire_param model_type="pi" R="0" C="0" num_level="1"/> <!-- model_type could be T, res_val cap_val should be defined -->
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level" prefix="mux_2level" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_2level_tapbuf" prefix="mux_2level_tapbuf" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="multi_level" num_level="2" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <circuit_model type="mux" name="mux_1level_tapbuf" prefix="mux_1level_tapbuf" is_default="true" dump_structural_verilog="true">
+      <design_technology type="cmos" structure="one_level" add_const_input="true" const_input_val="1"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="tap_buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="1"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="1"/>
+    </circuit_model>
+    <!--DFF subckt ports should be defined as <D> <Q> <CLK> <RESET> <SET>  -->
+    <circuit_model type="ff" name="DFFSRQ" prefix="DFFSRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+       <design_technology type="cmos"/>
+       <input_buffer exist="true" circuit_model_name="INVTX1"/>
+       <output_buffer exist="true" circuit_model_name="INVTX1"/>
+       <port type="input" prefix="D" size="1"/>
+       <port type="input" prefix="set" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true"/>
+       <port type="input" prefix="reset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true"/>
+       <port type="output" prefix="Q" size="1"/>
+       <port type="clock" prefix="clk" lib_name="CK" size="1" is_global="true" default_val="0" />
+    </circuit_model>
+    <circuit_model type="lut" name="lut4" prefix="lut4" dump_structural_verilog="true">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_inverter exist="true" circuit_model_name="INVTX1"/>
+      <lut_input_buffer exist="true" circuit_model_name="buf4"/>
+      <pass_gate_logic circuit_model_name="TGATE"/>
+      <port type="input" prefix="in" size="4"/>
+      <port type="output" prefix="out" size="1"/>
+      <port type="sram" prefix="sram" size="16"/>
+    </circuit_model>
+    <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
+    <circuit_model type="sram" name="LATCHSR" prefix="LATCHSR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/latch.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/latch.v">
+       <design_technology type="cmos"/>
+       <input_buffer exist="true" circuit_model_name="INVTX1"/>
+       <output_buffer exist="true" circuit_model_name="INVTX1"/>
+       <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
+       <port type="input" prefix="pSet" lib_name="SET" size="1" is_global="true" default_val="0" is_set="true" is_prog="true"/>
+       <port type="bl" prefix="bl" lib_name="D" size="1"/>
+       <port type="wl" prefix="wl" lib_name="WE" size="1"/>
+       <port type="output" prefix="Q" lib_name="Q" size="1"/>
+       <port type="output" prefix="Qb" lib_name="QN" size="1"/>
+    </circuit_model>
+    <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
+      <design_technology type="cmos"/>
+      <input_buffer exist="true" circuit_model_name="INVTX1"/>
+      <output_buffer exist="true" circuit_model_name="INVTX1"/>
+      <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="LATCHSR" default_val="1"/>
+      <port type="input" prefix="outpad" lib_name="A" size="1"/>
+      <port type="output" prefix="inpad" lib_name="Y" size="1"/>
+    </circuit_model>
+  </circuit_library>
+  <configuration_protocol>
+    <organization type="frame_based" circuit_model_name="LATCHSR" num_regions="4"/>
+  </configuration_protocol>
+  <connection_block>
+    <switch name="ipin_cblock" circuit_model_name="mux_2level_tapbuf"/>
+  </connection_block>
+  <switch_block>
+    <switch name="0" circuit_model_name="mux_2level_tapbuf"/>
+  </switch_block>
+  <routing_segment>
+    <segment name="L4" circuit_model_name="chan_segment"/>
+  </routing_segment>
+  <pb_type_annotations>
+    <!-- physical pb_type binding in complex block IO -->
+    <pb_type name="io" physical_mode_name="physical" idle_mode_name="inpad"/>
+    <pb_type name="io[physical].iopad" circuit_model_name="GPIO" mode_bits="1"/> 
+    <pb_type name="io[inpad].inpad" physical_pb_type_name="io[physical].iopad" mode_bits="1"/> 
+    <pb_type name="io[outpad].outpad" physical_pb_type_name="io[physical].iopad" mode_bits="0"/> 
+    <!-- End physical pb_type binding in complex block IO -->
+
+    <!-- physical pb_type binding in complex block CLB -->
+    <!-- physical mode will be the default mode if not specified -->
+    <pb_type name="clb">
+      <!-- Binding interconnect to circuit models as their physical implementation, if not defined, we use the default model -->
+      <interconnect name="crossbar" circuit_model_name="mux_2level"/>
+    </pb_type>
+    <pb_type name="clb.fle[n1_lut4].ble4.lut4" circuit_model_name="lut4"/>
+    <pb_type name="clb.fle[n1_lut4].ble4.ff" circuit_model_name="DFFSRQ"/>
+    <!-- End physical pb_type binding in complex block IO -->
+  </pb_type_annotations>
+</openfpga_architecture>

--- a/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/multi_region_configuration_frame/config/task.conf
@@ -1,0 +1,34 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/OpenFPGAShellScripts/full_testbench_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=

--- a/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_configuration_frame/config/task.conf
+++ b/openfpga_flow/tasks/basic_tests/full_testbench/smart_fast_multi_region_configuration_frame/config/task.conf
@@ -1,0 +1,34 @@
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# Configuration file for running experiments
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# timeout_each_job : FPGA Task script splits fpga flow into multiple jobs
+# Each job execute fpga_flow script on combination of architecture & benchmark
+# timeout_each_job is timeout for each job
+# = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+
+[GENERAL]
+run_engine=openfpga_shell
+power_tech_file = ${PATH:OPENFPGA_PATH}/openfpga_flow/tech/PTM_45nm/45nm.xml
+power_analysis = true
+spice_output=false
+verilog_output=true
+timeout_each_job = 20*60
+fpga_flow=yosys_vpr
+
+[OpenFPGA_SHELL]
+openfpga_shell_template=${PATH:OPENFPGA_PATH}/openfpga_flow/OpenFPGAShellScripts/fast_configuration_example_script.openfpga
+openfpga_arch_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_arch/k4_N4_40nm_multi_region_frame_use_both_set_reset_openfpga.xml
+openfpga_sim_setting_file=${PATH:OPENFPGA_PATH}/openfpga_flow/openfpga_simulation_settings/auto_sim_openfpga.xml
+
+[ARCHITECTURES]
+arch0=${PATH:OPENFPGA_PATH}/openfpga_flow/vpr_arch/k4_N4_tileable_40nm.xml
+
+[BENCHMARKS]
+bench0=${PATH:OPENFPGA_PATH}/openfpga_flow/benchmarks/micro_benchmark/and2/and2.v
+
+[SYNTHESIS_PARAM]
+bench0_top = and2
+bench0_chan_width = 300
+
+[SCRIPT_PARAM_MIN_ROUTE_CHAN_WIDTH]
+end_flow_with_test=


### PR DESCRIPTION
Now frame-based configuration protocol supports multi-region as configuration chain and memory banks
In addition, fabric bitstream now supports don't care bit for frame-based addresses