### PR TITLE
Remove the restrictions on requiring two outputs for configurable memory circuits

### DIFF
--- a/docs/source/manual/arch_lang/circuit_library.rst
+++ b/docs/source/manual/arch_lang/circuit_library.rst
@@ -176,6 +176,8 @@ A circuit model may consist of a number of ports. The port list is mandatory in 
 
   - ``is_data_io="true|false"`` Specify if this port should be treated as a mappable FPGA I/O port for users' implementation. When this is enabled, I/Os of user's implementation, e.g., ``.input`` and ``.output`` in ``.blif`` netlist, can be mapped to the port through VPR.
 
+    .. note:: Any I/O model must have at least 1 port that is defined as data I/O!
+
   - ``mode_select="true|false"`` Specify if this port controls the mode switching in a configurable logic block. This is due to that a configurable logic block can operate in different modes, which is controlled by SRAM bits.
 
     .. note:: ``mode_select`` is only valid when the type of this port is ``sram``.

--- a/docs/source/manual/arch_lang/circuit_library.rst
+++ b/docs/source/manual/arch_lang/circuit_library.rst
@@ -143,7 +143,8 @@ A circuit model may consist of a number of ports. The port list is mandatory in 
 
 .. option:: <port type="<string>" prefix="<string>" lib_name="<string>" size="<int>"
   default_val="<int>" circuit_model_name="<string>" mode_select="<bool>"
-  is_global="<bool>" is_set="<bool>" is_reset="<bool>" is_config_enable="<bool>"/>
+  is_global="<bool>" is_set="<bool>" is_reset="<bool>" 
+  is_config_enable="<bool>" is_io="<bool>" is_data_io="<bool>"/>
 
   Define the attributes for a port of a circuit model.
 
@@ -169,9 +170,11 @@ A circuit model may consist of a number of ports. The port list is mandatory in 
 
     .. note:: ``circuit_model_name`` is only valid when the type of this port is ``sram``.
 
-  - ``io="true|false"`` Specify if this port should be treated as an I/O port of an FPGA fabric. When this is enabled, this port of each circuit model instanciated in FPGA will be added as an I/O of an FPGA.
+  - ``is_io="true|false"`` Specify if this port should be treated as an I/O port of an FPGA fabric. When this is enabled, this port of each circuit model instanciated in FPGA will be added as an I/O of an FPGA.
 
     .. note:: global ``output`` ports must be ``io`` ports
+
+  - ``is_data_io="true|false"`` Specify if this port should be treated as a mappable FPGA I/O port for users' implementation. When this is enabled, I/Os of user's implementation, e.g., ``.input`` and ``.output`` in ``.blif`` netlist, can be mapped to the port through VPR.
 
   - ``mode_select="true|false"`` Specify if this port controls the mode switching in a configurable logic block. This is due to that a configurable logic block can operate in different modes, which is controlled by SRAM bits.
 

--- a/docs/source/manual/arch_lang/circuit_model_examples.rst
+++ b/docs/source/manual/arch_lang/circuit_model_examples.rst
@@ -832,7 +832,7 @@ Template
 
   - ``type="ccff|ff"`` Specify the type of a flip-flop. ``ff`` is a regular flip-flop while ``ccff`` denotes a configuration-chain flip-flop
 
-.. note:: A flip-flop should have three types of ports, ``input``, ``output`` and ``clock``.
+.. note:: A flip-flop should at least have three types of ports, ``input``, ``output`` and ``clock``.
 
 .. note:: If the user provides a customized Verilog/SPICE netlist, the bandwidth of ports should be defined to the same as the Verilog/SPICE netlist.
 
@@ -891,7 +891,8 @@ The code describing this FF is:
 
   <circuit_model type="ccff" name="ccff" prefix="ccff" verilog_netlist="ccff.v" spice_netlist="ccff.sp">
     <port type="input" prefix="D" size="1"/>
-    <port type="output" prefix="Q" size="2"/>
+    <port type="output" prefix="Q" size="1"/>
+    <port type="output" prefix="Qb" size="1"/>
     <port type="clock" prefix="CK" size="1" is_global="true"/>
   </circuit_model>
 
@@ -1053,7 +1054,7 @@ The code describing this I/O-Pad is:
     <input_buffer exist="true" circuit_model_name="INVTX1"/>
     <output_buffer exist="true" circuit_model_name="INVTX1"/>
     <pass_gate_logic circuit_model_name="TGATE"/>
-    <port type="inout" prefix="pad" size="1"/>
+    <port type="inout" prefix="pad" size="1" is_global="true" is_io="true" is_data_io="true"/>
     <port type="sram" prefix="en" size="1" mode_select="true" circuit_model_name="ccff" default_val="1"/>
     <port type="input" prefix="outpad" size="1"/>
     <port type="output" prefix="inpad" size="1"/>

--- a/libopenfpga/libarchopenfpga/src/check_circuit_library.cpp
+++ b/libopenfpga/libarchopenfpga/src/check_circuit_library.cpp
@@ -299,10 +299,11 @@ size_t check_ccff_circuit_model_ports(const CircuitLibrary& circuit_lib,
                                                                  1, 1, true);
 
 
-  /* Check if we have output */
+  /* Check if we have 1 or 2 outputs */
+  size_t num_output_ports = circuit_lib.model_ports_by_type(circuit_model, CIRCUIT_MODEL_PORT_OUTPUT, true).size();
   num_err += check_one_circuit_model_port_type_and_size_required(circuit_lib, circuit_model, 
                                                                  CIRCUIT_MODEL_PORT_OUTPUT,
-                                                                 1, 1, false);
+                                                                 num_output_ports, 1, false);
 
   return num_err;
 }

--- a/libopenfpga/libarchopenfpga/src/check_circuit_library.cpp
+++ b/libopenfpga/libarchopenfpga/src/check_circuit_library.cpp
@@ -302,7 +302,7 @@ size_t check_ccff_circuit_model_ports(const CircuitLibrary& circuit_lib,
   /* Check if we have output */
   num_err += check_one_circuit_model_port_type_and_size_required(circuit_lib, circuit_model, 
                                                                  CIRCUIT_MODEL_PORT_OUTPUT,
-                                                                 2, 1, false);
+                                                                 1, 1, false);
 
   return num_err;
 }

--- a/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
+++ b/openfpga/src/fpga_bitstream/build_device_bitstream.cpp
@@ -152,10 +152,6 @@ BitstreamManager build_device_bitstream(const VprContext& vpr_ctx,
   /* Bitstream manager to be built */
   BitstreamManager bitstream_manager;
 
-  /* Assign the SRAM model applied to the FPGA fabric */
-  CircuitModelId sram_model = openfpga_ctx.arch().config_protocol.memory_model();  
-  VTR_ASSERT(true == openfpga_ctx.arch().circuit_lib.valid_model_id(sram_model));
-
   /* Create the top-level block for bitstream 
    * This is related to the top-level module of fpga  
    */

--- a/openfpga/src/fpga_verilog/verilog_api.cpp
+++ b/openfpga/src/fpga_verilog/verilog_api.cpp
@@ -181,6 +181,7 @@ void fpga_verilog_testbench(const ModuleManager &module_manager,
   if (true == options.print_formal_verification_top_netlist()) {
     std::string formal_verification_top_netlist_file_path = src_dir_path + netlist_name + std::string(FORMAL_VERIFICATION_VERILOG_FILE_POSTFIX);
     print_verilog_preconfig_top_module(module_manager, bitstream_manager,
+                                       config_protocol,
                                        circuit_lib, global_ports,
                                        atom_ctx, place_ctx, io_location_map,
                                        netlist_annotation,

--- a/openfpga/src/fpga_verilog/verilog_preconfig_top_module.h
+++ b/openfpga/src/fpga_verilog/verilog_preconfig_top_module.h
@@ -11,6 +11,7 @@
 #include "module_manager.h"
 #include "bitstream_manager.h"
 #include "io_location_map.h"
+#include "config_protocol.h"
 #include "vpr_netlist_annotation.h"
 
 /********************************************************************
@@ -22,6 +23,7 @@ namespace openfpga {
 
 void print_verilog_preconfig_top_module(const ModuleManager& module_manager,
                                         const BitstreamManager& bitstream_manager,
+                                        const ConfigProtocol &config_protocol,
                                         const CircuitLibrary& circuit_lib,
                                         const std::vector<CircuitPortId>& global_ports,
                                         const AtomContext& atom_ctx,

--- a/openfpga/src/utils/module_manager_utils.cpp
+++ b/openfpga/src/utils/module_manager_utils.cpp
@@ -776,7 +776,7 @@ void add_module_nets_between_logic_and_memory_sram_bus(ModuleManager& module_man
 
   /* Do wiring only when we have sramb ports */
   if ( (false == logic_module_sramb_port_ids.empty())
-    || (ModulePortId::INVALID() == mem_module_sramb_port_id) ) {
+    && (ModulePortId::INVALID() != mem_module_sramb_port_id) ) {
     add_module_nets_between_logic_and_memory_sram_ports(module_manager, parent_module, 
                                                         logic_module, logic_instance_id,
                                                         memory_module, memory_instance_id,

--- a/openfpga_flow/openfpga_arch/k4_frac_N8_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k4_frac_N8_register_scan_chain_caravel_io_skywater130nm_fdhd_cc_openfpga.xml
@@ -172,16 +172,15 @@
       <port type="output" prefix="lut3_out" size="2" lut_frac_level="3" lut_output_mask="0,1"/>
       <port type="output" prefix="lut4_out" size="1" lut_output_mask="0"/>
       <port type="sram" prefix="sram" size="16"/>
-      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFF" default_val="1"/>
+      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFQ" default_val="1"/>
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
-    <circuit_model type="ccff" name="DFF" prefix="DFF" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+    <circuit_model type="ccff" name="DFFQ" prefix="DFFQ" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
       <design_technology type="cmos"/>
       <input_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
       <output_buffer exist="true" circuit_model_name="sky130_fd_sc_hd__inv_1"/>
       <port type="input" prefix="D" size="1"/>
       <port type="output" prefix="Q" size="1"/>
-      <port type="output" prefix="QN" size="1"/>
       <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="EMBEDDED_IO" prefix="EMBEDDED_IO" is_default="true" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
@@ -193,11 +192,11 @@
       <port type="output" prefix="SOC_DIR" lib_name="SOC_DIR" size="1" is_global="true" is_io="true"/>
       <port type="output" prefix="inpad" lib_name="FPGA_IN" size="1"/>
       <port type="input" prefix="outpad" lib_name="FPGA_OUT" size="1"/>
-      <port type="sram" prefix="en" lib_name="FPGA_DIR" size="1" mode_select="true" circuit_model_name="DFF" default_val="1"/>
+      <port type="sram" prefix="en" lib_name="FPGA_DIR" size="1" mode_select="true" circuit_model_name="DFFQ" default_val="1"/>
     </circuit_model>
   </circuit_library>
   <configuration_protocol>
-    <organization type="scan_chain" circuit_model_name="DFF" num_regions="1"/>
+    <organization type="scan_chain" circuit_model_name="DFFQ" num_regions="1"/>
   </configuration_protocol>
   <connection_block>
     <switch name="ipin_cblock" circuit_model_name="mux_tree_tapbuf"/>

--- a/openfpga_flow/openfpga_arch/k6_frac_N8_stdcell_mux_40nm_openfpga.xml
+++ b/openfpga_flow/openfpga_arch/k6_frac_N8_stdcell_mux_40nm_openfpga.xml
@@ -153,17 +153,16 @@
       <port type="output" prefix="lut5_out" size="2" lut_frac_level="5" lut_output_mask="0,1"/>
       <port type="output" prefix="lut6_out" size="1" lut_output_mask="0"/>
       <port type="sram" prefix="sram" size="64"/>
-      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
+      <port type="sram" prefix="mode" size="1" mode_select="true" circuit_model_name="DFFRQ" default_val="1"/>
     </circuit_model>
     <!--Scan-chain DFF subckt ports should be defined as <D> <Q> <Qb> <CLK> <RESET> <SET>  -->
-    <circuit_model type="ccff" name="DFFR" prefix="DFFR" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
+    <circuit_model type="ccff" name="DFFRQ" prefix="DFFRQ" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/dff.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/dff.v">
        <design_technology type="cmos"/>
        <input_buffer exist="true" circuit_model_name="INVTX1"/>
        <output_buffer exist="true" circuit_model_name="INVTX1"/>
        <port type="input" prefix="pReset" lib_name="RST" size="1" is_global="true" default_val="0" is_reset="true" is_prog="true"/>
        <port type="input" prefix="D" size="1"/>
        <port type="output" prefix="Q" size="1"/>
-       <port type="output" prefix="QN" size="1"/>
        <port type="clock" prefix="prog_clk" lib_name="CK" size="1" is_global="true" default_val="0" is_prog="true"/>
     </circuit_model>
     <circuit_model type="iopad" name="GPIO" prefix="GPIO" spice_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/spice/gpio.sp" verilog_netlist="${OPENFPGA_PATH}/openfpga_flow/openfpga_cell_library/verilog/gpio.v">
@@ -171,13 +170,13 @@
       <input_buffer exist="true" circuit_model_name="INVTX1"/>
       <output_buffer exist="true" circuit_model_name="INVTX1"/>
       <port type="inout" prefix="PAD" size="1" is_global="true" is_io="true" is_data_io="true"/>
-      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="DFFR" default_val="1"/>
+      <port type="sram" prefix="DIR" size="1" mode_select="true" circuit_model_name="DFFRQ" default_val="1"/>
       <port type="input" prefix="outpad" lib_name="A" size="1"/>
       <port type="output" prefix="inpad" lib_name="Y" size="1"/>
     </circuit_model>
   </circuit_library>
   <configuration_protocol>
-    <organization type="scan_chain" circuit_model_name="DFFR"/>
+    <organization type="scan_chain" circuit_model_name="DFFRQ"/>
   </configuration_protocol>
   <connection_block>
     <switch name="ipin_cblock" circuit_model_name="mux_tree_tapbuf"/>

--- a/openfpga_flow/openfpga_cell_library/verilog/dff.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dff.v
@@ -5,6 +5,31 @@
 //-----------------------------------------------------
 
 //-----------------------------------------------------
+// Function    : A native D-type flip-flop with single output
+//-----------------------------------------------------
+module DFFQ (
+  input CK, // Clock Input
+  input D, // Data Input
+  output Q // Q output
+);
+//------------Internal Variables--------
+reg q_reg;
+
+//-------------Code Starts Here---------
+always @ (posedge CK) begin 
+  q_reg <= D;
+end
+
+// Wire q_reg to Q
+`ifndef ENABLE_FORMAL_VERIFICATION
+  assign Q = q_reg;
+`else
+  assign Q = 1'bZ;
+`endif
+
+endmodule //End Of Module
+
+//-----------------------------------------------------
 // Function    : A native D-type flip-flop
 //-----------------------------------------------------
 module DFF (

--- a/openfpga_flow/openfpga_cell_library/verilog/dff.v
+++ b/openfpga_flow/openfpga_cell_library/verilog/dff.v
@@ -59,6 +59,38 @@ endmodule //End Of Module
 
 //-----------------------------------------------------
 // Function    : D-type flip-flop with 
+//               - single output
+//               - asynchronous active high reset
+//-----------------------------------------------------
+module DFFRQ (
+  input RST, // Reset input
+  input CK, // Clock Input
+  input D, // Data Input
+  output Q // Q output
+);
+//------------Internal Variables--------
+reg q_reg;
+
+//-------------Code Starts Here---------
+always @ ( posedge CK or posedge RST)
+if (RST) begin
+  q_reg <= 1'b0;
+end else begin
+  q_reg <= D;
+end
+
+// Wire q_reg to Q
+`ifndef ENABLE_FORMAL_VERIFICATION
+  assign Q = q_reg;
+`else
+  assign Q = 1'bZ;
+`endif
+
+endmodule //End Of Module
+
+
+//-----------------------------------------------------
+// Function    : D-type flip-flop with 
 //               - asynchronous active high reset
 //-----------------------------------------------------
 module DFFR (


### PR DESCRIPTION
Previously, all the configurable memory circuit models need two outputs, e.g., one for Q and the other for Qb, to generate fabric netlists and testbenches.
As standard cell FPGA does not require Qb to configure multiplexers, this may cause area overhead.
This pull request remove the restrictions.