### PR TITLE
Multiple Bug Fixes

### DIFF
--- a/openfpga/src/fabric/build_top_module.cpp
+++ b/openfpga/src/fabric/build_top_module.cpp
@@ -381,6 +381,7 @@ int build_top_module(ModuleManager& module_manager,
     }
 
     status = load_top_module_memory_modules_from_fabric_key(module_manager, top_module,
+                                                            circuit_lib, config_protocol,
                                                             fabric_key); 
     if (CMD_EXEC_FATAL_ERROR == status) {
       return status;

--- a/openfpga/src/fabric/build_top_module_memory.cpp
+++ b/openfpga/src/fabric/build_top_module_memory.cpp
@@ -523,6 +523,8 @@ void shuffle_top_module_configurable_children(ModuleManager& module_manager,
  ********************************************************************/
 int load_top_module_memory_modules_from_fabric_key(ModuleManager& module_manager,
                                                    const ModuleId& top_module,
+                                                   const CircuitLibrary& circuit_lib,
+                                                   const ConfigProtocol& config_protocol,
                                                    const FabricKey& fabric_key) {
   /* Ensure a clean start */
   module_manager.clear_configurable_children(top_module);
@@ -570,6 +572,20 @@ int load_top_module_memory_modules_from_fabric_key(ModuleManager& module_manager
         } else {
           VTR_LOG_ERROR("Invalid key value '%ld'!\n",
                         instance_info.second); 
+        }
+        return CMD_EXEC_FATAL_ERROR;                    
+      }
+
+      /* If the the child has not configuration bits, error out */
+      if (0 == find_module_num_config_bits(module_manager, instance_info.first,
+                                           circuit_lib, config_protocol.memory_model(), 
+                                           config_protocol.type())) {
+        if (!fabric_key.key_alias(key).empty()) {
+          VTR_LOG_ERROR("Invalid key alias '%s' which has zero configuration bits!\n",
+                        fabric_key.key_alias(key).c_str()); 
+        } else {
+          VTR_LOG_ERROR("Invalid key name '%s' which has zero configuration bits!\n",
+                        fabric_key.key_name(key).c_str()); 
         }
         return CMD_EXEC_FATAL_ERROR;                    
       }

--- a/openfpga/src/fabric/build_top_module_memory.h
+++ b/openfpga/src/fabric/build_top_module_memory.h
@@ -44,6 +44,8 @@ void shuffle_top_module_configurable_children(ModuleManager& module_manager,
 
 int load_top_module_memory_modules_from_fabric_key(ModuleManager& module_manager,
                                                    const ModuleId& top_module,
+                                                   const CircuitLibrary& circuit_lib,
+                                                   const ConfigProtocol& config_protocol,
                                                    const FabricKey& fabric_key); 
 
 vtr::vector<ConfigRegionId, size_t> find_top_module_regional_num_config_bit(const ModuleManager& module_manager,

--- a/openfpga/src/utils/openfpga_device_grid_utils.cpp
+++ b/openfpga/src/utils/openfpga_device_grid_utils.cpp
@@ -43,12 +43,12 @@ std::map<e_side, std::vector<vtr::Point<size_t>>> generate_perimeter_grid_coordi
   } 
 
   /* RIGHT side */
-  for (size_t iy = 1; iy < grids.height() - 1; ++iy) { 
+  for (size_t iy = grids.height() - 2; iy > 0; --iy) { 
     io_coordinates[RIGHT].push_back(vtr::Point<size_t>(grids.width() - 1, iy));
   } 
 
   /* BOTTOM side*/
-  for (size_t ix = 1; ix < grids.width() - 1; ++ix) { 
+  for (size_t ix = grids.width() - 2; ix > 0; --ix) { 
     io_coordinates[BOTTOM].push_back(vtr::Point<size_t>(ix, 0));
   } 
 


### PR DESCRIPTION
- Enhance error checking in fabric key parser: Only configurable blocks can be accepted as a key component
- Adapt the i/o numbering to the clockwise sequence which is more nature