### PR TITLE
Fix for rr graph loading by VPR

### DIFF
--- a/vpr/src/device/check_rr_graph_obj.cpp
+++ b/vpr/src/device/check_rr_graph_obj.cpp
@@ -70,7 +70,7 @@ static bool check_rr_graph_dangling_nodes(const RRGraph& rr_graph) {
         if ((0 == rr_graph.node_fan_in(node))
             && (0 == rr_graph.node_fan_out(node))) {
             /* Print a warning! */
-            VTR_LOG_WARN("Node %s is dangling (zero fan-in and zero fan-out)!\n",
+            VTR_LOG_WARN("Node %d is dangling (zero fan-in and zero fan-out)!\n",
                          node);
             VTR_LOG_WARN("Node details for debugging:\n");
             rr_graph.print_node(node);

--- a/vpr/src/device/rr_graph_obj.cpp
+++ b/vpr/src/device/rr_graph_obj.cpp
@@ -449,6 +449,7 @@ void RRGraph::print_node(const RRNodeId& node) const {
     VTR_LOG("Node ptc: %d\n", node_ptc_num(node));
     VTR_LOG("Node num in_edges: %d\n", node_in_edges(node).size());
     VTR_LOG("Node num out_edges: %d\n", node_out_edges(node).size());
+    VTR_LOG("Node segment id: %d\n", node_segment(node));
 }
 
 /* Check if the segment id of a node is in range */

--- a/vpr/src/device/rr_graph_obj.cpp
+++ b/vpr/src/device/rr_graph_obj.cpp
@@ -449,7 +449,10 @@ void RRGraph::print_node(const RRNodeId& node) const {
     VTR_LOG("Node ptc: %d\n", node_ptc_num(node));
     VTR_LOG("Node num in_edges: %d\n", node_in_edges(node).size());
     VTR_LOG("Node num out_edges: %d\n", node_out_edges(node).size());
-    VTR_LOG("Node segment id: %d\n", node_segment(node));
+
+    if (node_type(node) == CHANX || node_type(node) == CHANY) {
+        VTR_LOG("Node segment id: %d\n", node_segment(node));
+    }
 }
 
 /* Check if the segment id of a node is in range */


### PR DESCRIPTION
I've noticed that in the modified VPR version used by OpenFPGA segment ids are not set when a rr graph is loaded.

In this PR I've fixed that by creating segments in the `RRGraph` class and assigning them to nodes read from a rr graph XML file. I've also moved the essential check of the loaded rr graph after segment processing.